### PR TITLE
Update react peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/gaearon/react-hot-api",
   "peerDependencies": {
-    "react": ">=0.11.0"
+    "react": ">=0.11.0 || >=0.13.0-beta.1"
   },
   "devDependencies": {
     "webpack": "1.4.8"


### PR DESCRIPTION
This was preventing me from running `npm i --save react@0.13.0-beta.1` in [`react-hot-boilerplate`][rhb] after I had already run `npm i`. I did some basic testing any everything appears to still work.

[rhb]: https://github.com/gaearon/react-hot-boilerplate "react-hot-boilerplate"