### PR TITLE
Component inheritance hot reload

### DIFF
--- a/modules/makeAssimilatePrototype.js
+++ b/modules/makeAssimilatePrototype.js
@@ -55,7 +55,7 @@ module.exports = function makeAssimilatePrototype() {
   }
 
   return function assimilatePrototype(freshPrototype) {
-    if (freshPrototype.__isAssimilatedByReactHotAPI) {
+    if (Object.prototype.hasOwnProperty.call(freshPrototype, '__isAssimilatedByReactHotAPI')) {
       return;
     }
 


### PR DESCRIPTION
Now that components are plain JS classes, it can inherit from other components.

This fix ensure the actual component prototype is patched for hot reload, and not one of its parent.