### PR TITLE
Handle method getters and setters

### DIFF
--- a/modules/makeAssimilatePrototype.js
+++ b/modules/makeAssimilatePrototype.js
@@ -13,12 +13,14 @@ module.exports = function makeAssimilatePrototype() {
     if (typeof descriptor[descKey] === 'function') {
       descriptor[descKey] = function (firstArgument) {
         var storedDescriptor = Object.getOwnPropertyDescriptor(storedPrototype, key);
-        if (typeof storedDescriptor[descKey] === 'function') {
-          return storedDescriptor[descKey].apply(this, arguments);
-        } else if (descKey === 'get') {
-          return this[key];
-        } else if (descKey === 'set') {
-          this[key] = firstArgument;
+        if (storedDescriptor) {
+          if (typeof storedDescriptor[descKey] === 'function') {
+            return storedDescriptor[descKey].apply(this, arguments);
+          } else if (descKey === 'get') {
+            return this[key];
+          } else if (descKey === 'set') {
+            this[key] = firstArgument;
+          }
         }
       };
     }

--- a/modules/makeAssimilatePrototype.js
+++ b/modules/makeAssimilatePrototype.js
@@ -9,39 +9,45 @@ module.exports = function makeAssimilatePrototype() {
   var storedPrototype,
       knownPrototypes = [];
 
-  function wrapMethod(key) {
-    return function () {
-      if (storedPrototype[key]) {
-        return storedPrototype[key].apply(this, arguments);
-      }
-    };
+  function wrapMethod(key, descriptor, descKey) {
+    if (typeof descriptor[descKey] === 'function') {
+      descriptor[descKey] = function (firstArgument) {
+        var storedDescriptor = Object.getOwnPropertyDescriptor(storedPrototype, key);
+        if (typeof storedDescriptor[descKey] === 'function') {
+          return storedDescriptor[descKey].apply(this, arguments);
+        } else if (descKey === 'get') {
+          return this[key];
+        } else if (descKey === 'set') {
+          this[key] = firstArgument;
+        }
+      };
+    }
   }
 
   function patchProperty(proto, key) {
-    proto[key] = storedPrototype[key];
+    var descriptor = Object.getOwnPropertyDescriptor(storedPrototype, key);
 
-    if (typeof proto[key] !== 'function' ||
-      key === 'type' ||
-      key === 'constructor') {
-      return;
+    if ((descriptor.get || descriptor.set || typeof descriptor.value === 'function') &&
+      key !== 'type' &&
+      key !== 'constructor') {
+
+      wrapMethod(key, descriptor, 'get');
+      wrapMethod(key, descriptor, 'set');
+      wrapMethod(key, descriptor, 'value');
+
+      if (proto.__reactAutoBindMap && proto.__reactAutoBindMap[key]) {
+        proto.__reactAutoBindMap[key] = proto[key];
+      }
     }
 
-    proto[key] = wrapMethod(key);
-
-    if (storedPrototype[key].isReactClassApproved) {
-      proto[key].isReactClassApproved = storedPrototype[key].isReactClassApproved;
-    }
-
-    if (proto.__reactAutoBindMap && proto.__reactAutoBindMap[key]) {
-      proto.__reactAutoBindMap[key] = proto[key];
-    }
+    Object.defineProperty(proto, key, descriptor);
   }
 
   function updateStoredPrototype(freshPrototype) {
     storedPrototype = {};
 
     Object.getOwnPropertyNames(freshPrototype).forEach(function (key) {
-      storedPrototype[key] = freshPrototype[key];
+      Object.defineProperty(storedPrototype, key, Object.getOwnPropertyDescriptor(freshPrototype, key));
     });
   }
 


### PR DESCRIPTION
This patch fixes `react-hot-api` for components with getters and setters, ex:
```js
class App extends Component {
    get foo() {
        return this.state.foo;
    }
    ...
}
```

Please note that I removed the lines:
```js
if (storedPrototype[key].isReactClassApproved) {
  proto[key].isReactClassApproved = storedPrototype[key].isReactClassApproved;
}
```
as I didn't find any usage of this property in `react-hot-api`, `react-hot-loader` or `react` itself. It may be added again in another way, but is it really needed?