### PR TITLE
Fixed autoBinding of new methods

### DIFF
--- a/modules/bindAutoBindMethods.js
+++ b/modules/bindAutoBindMethods.js
@@ -46,6 +46,9 @@ function bindAutoBindMethod(component, method) {
  * Based on https://github.com/facebook/react/blob/master/src/classic/class/ReactClass.js#L639-L685.
  */
 module.exports = function bindAutoBindMethods(component) {
+  
+  component = component._instance || component;
+  
   for (var autoBindKey in component.__reactAutoBindMap) {
     if (!component.__reactAutoBindMap.hasOwnProperty(autoBindKey)) {
       continue;


### PR DESCRIPTION
If you add a method to the component and use it in `render` it will not work due to binding issues, "this is undefined". I located a problem in `bindAutoBindMethods` where `__reactAutoBindMap` is not available. There seems to be a change in React where you have to grab it from the `_instance` property.

This fixed the problem, but I am no wiz at how this should work. Hopefully this fix will do :-)