### PR TITLE
Experimental: handle render errors

### DIFF
--- a/modules/makeAssimilatePrototype.js
+++ b/modules/makeAssimilatePrototype.js
@@ -5,11 +5,41 @@
  * as the "source of truth" and patches its methods on subsequent invocations,
  * also patching current and previous prototypes to forward calls to it.
  */
-module.exports = function makeAssimilatePrototype() {
+module.exports = function makeAssimilatePrototype(React) {
   var storedPrototype,
       knownPrototypes = [];
 
   function wrapMethod(key) {
+    if (key === 'render') {
+      return function render() {
+        try {
+          if (storedPrototype[key]) {
+            return storedPrototype[key].apply(this, arguments);
+          }
+        } catch (err) {
+          console.error(err);
+          return React.createElement('div', {
+            style: {
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'red',
+              opacity: 0.6,
+              fontSize: 18,
+              color: 'white',
+              textAlign: 'center',
+              padding: 40,
+              display: 'table'
+            }
+          }, React.createElement('span', {
+            style: {
+              display: 'table-cell',
+              verticalAlign: 'middle'
+            }
+          }, err.toString()));
+        }
+      };
+    }
+
     return function () {
       if (storedPrototype[key]) {
         return storedPrototype[key].apply(this, arguments);

--- a/modules/makePatchReactClass.js
+++ b/modules/makePatchReactClass.js
@@ -32,7 +32,7 @@ function getPrototype(ReactClass) {
  * on subsequent invocations. Both legacy and ES6 style classes are supported.
  */
 module.exports = function makePatchReactClass(getRootInstances, React) {
-  var assimilatePrototype = makeAssimilatePrototype(),
+  var assimilatePrototype = makeAssimilatePrototype(React),
       FirstClass = null;
 
   return function patchReactClass(NextClass) {


### PR DESCRIPTION
It's pretty frustrating to have a `render` error blow up your app.
Here's an experiment in handling them.

May be worth doing for other lifecycle hooks to prevent hot updates blowing up the app.
Feedback welcome.

Open questions:

* How to make this work in React Native
* How configurable it needs to be
* Whether other lifecycle hooks need similar protection