### PR TITLE
support react 0.14.0-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/gaearon/react-hot-api",
   "peerDependencies": {
-    "react": ">=0.11.0 || 0.13.0-beta.1 || 0.13.0-rc1 || 0.13.0-rc2"
+    "react": ">=0.11.0 || 0.13.0-beta.1 || 0.13.0-rc1 || 0.13.0-rc2 || 0.14.0-beta1"
   },
   "devDependencies": {
     "webpack": "1.4.8"


### PR DESCRIPTION
This fix makes using react-hot-loader with react 0.14.0-beta1 possible