### PR TITLE
delete something that may be a typo…?

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You may also give user some way to access `makeHot` in case they want to allow h
 ##### AnonComponents.js
 ```javascript
 // The user still doesn't need to know these lines are being inserted by the tool:
-var module.makeHot = SOME_STORAGE_SHARED_BETWEEN_VERSIONS_OF_SAME_MODULE.makeHot;
+module.makeHot = SOME_STORAGE_SHARED_BETWEEN_VERSIONS_OF_SAME_MODULE.makeHot;
 if (!module.makeHot) {
   // put the function into some sane place (e.g. module.makeHot) without relying on hidden variables
   module.makeHot = SOME_STORAGE_SHARED_BETWEEN_VERSIONS_OF_SAME_MODULE.makeHot = require('react-hot-api')(require('react/lib/ReactMount'));


### PR DESCRIPTION
I have no idea what `var module.foo = bar` does. Babel doesn't seem to recognize it. I'm thinking it's probably just a copy/paste error.

But if not, I'd love an explanation!

(cc @dmnd)