### PR TITLE
when wrapping a render method, overwrite toString as well

### DIFF
--- a/modules/makeAssimilatePrototype.js
+++ b/modules/makeAssimilatePrototype.js
@@ -10,11 +10,15 @@ module.exports = function makeAssimilatePrototype() {
       knownPrototypes = [];
 
   function wrapMethod(key) {
-    return function () {
+    var wrappedMethods = function() {
       if (storedPrototype[key]) {
         return storedPrototype[key].apply(this, arguments);
       }
     };
+    wrappedMethods.toString = function() {
+      return storedPrototype[key].toString();
+    };
+    return wrappedMethods;
   }
 
   function patchProperty(proto, key) {


### PR DESCRIPTION
I like to use toString to get a string which I match and then I can observe my stores. Without this change, I cannot run my regex against the wrapped function toString. See  https://github.com/capaj/react-observe-store/issues/1 for a better explanation