### PR TITLE
Add mount check before invoking RAF.

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -10,15 +10,18 @@ var getForceUpdate = require('react-proxy').getForceUpdate;
 function makePatchReactClass(React) {
   var forceUpdate = getForceUpdate(React);
   var proxy;
+  var canUpdate = typeof requestAnimationFrame === 'function';
 
   return function patchReactClass(NextClass) {
     if (!proxy) {
       proxy = createProxy(NextClass);
     } else {
       var mountedInstances = proxy.update(NextClass);
-      requestAnimationFrame(function () {
-        mountedInstances.forEach(forceUpdate);
-      });
+      if (canUpdate && mountedInstances.length > 0) {
+        requestAnimationFrame(function () {
+          mountedInstances.forEach(forceUpdate);
+        });
+      }
     }
 
     return proxy.get();


### PR DESCRIPTION
Server-side hot reloading, for which no components are never mounted, has no `requestAnimationFrame` and so the HMR runtime fails with "Cannot not apply hot update to ...: requestAnimationFrame is not defined". Adding this simple check ensures server-side hot reloading works and has no ill effects on the client.