### PR TITLE
Add support for react@15.0.0-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/gaearon/react-hot-api",
   "peerDependencies": {
-    "react": ">=0.11.0 || ^0.14.0-rc"
+    "react": ">=0.11.0 || ^0.14.0-rc || ^15.0.0-rc"
   },
   "devDependencies": {
     "webpack": "1.4.8"


### PR DESCRIPTION
I have a project that is still using the 0.4 release and this peer dependency is blocking me from trying out React 15. Would you might adding support on this branch?
